### PR TITLE
Removed duplicate ghash.io coinbase tag

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -60,10 +60,6 @@
                         "name" : "GHash.IO",
                         "link" : "https://ghash.io/"
                 },
-                "ghash.io" : {
-                        "name" : "GHash.IO",
-                        "link" : "https://ghash.io/"
-                },
                 "st mining corp" : {
                         "name" : "ST Mining Corp",
                         "link" : "https://bitcointalk.org/index.php?topic=77000.msg3207708#msg3207708"


### PR DESCRIPTION
It probably doesn't matter all that much, but it was a redundant duplicate.
