### PR TITLE
Possible Kano CKPool detection fix

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -144,7 +144,7 @@
             "name" : "Cointerra",
             "link" : "http://cointerra.com/"
         },
-        "ckpool/Kano" : {
+        "Kano" : {
             "name" : "Kano CKPool",
             "link" : "https://www.kano.is/"
         },


### PR DESCRIPTION
Latest block found by this pool https://blockchain.info/block-height/350334 is still not detected.