### PR TITLE
add BTC Pool Party pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -309,6 +309,10 @@
         "152f1muMCNa7goXYhYAQC61hxEgGacmncB" : {
             "name" : "BTCChina Pool",
             "link" : "https://pool.btcchina.com/"
+        },
+        "1PmRrdp1YSkp1LxPyCfcmBHDEipG5X4eJB" : {
+            "name" : "BTC Pool Party",
+            "link" : "https://btcpoolparty.com/"
         }
     }
 }


### PR DESCRIPTION
This seems to be the only consistent address this pool pays out to. They have found 1 block so far and only the 1PmRrdp1YSkp1LxPyCfcmBHDEipG5X4eJB fee address matches what they are currently mining to as the other two addresses are different.
https://blockchain.info/tx/ae05491d46b5f80feb6cb520921bf09db7be12ccb62a3a5b1cf8f835d588c465
Current decoded stratum payout split:
Coinbase output: 2448154112 -- 16NonTeX4Wy42SdYJrgL5QW77WBHquPJns
Coinbase output:   50477404 -- 1JffQu8WzPqn3bqKKF159iAG3mjpEtQroF
Coinbase output:   25238702 -- 1PmRrdp1YSkp1LxPyCfcmBHDEipG5X4eJB