### PR TITLE
add btcdig pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -377,6 +377,10 @@
         "1MeffGLauEj2CZ18hRQqUauTXb9JAuLbGw" : {
             "name" : "Multipool",
             "link" : "https://www.multipool.us/"
+        },
+        "15MxzsutVroEE9XiDckLxUHTCDAEZgPZJi" : {
+            "name" : "BTCDig",
+            "link" : "https://btcdig.com/"
         }
     }
 }


### PR DESCRIPTION
This pool seems to be active with only a small amount of hashrate but has found historical blocks, address confirmed via https://btcdig.com/stats/blocks/ and stratum decoder.