### PR TITLE
Fix A-XBT Coinbase tag

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -4,7 +4,7 @@
             "name" : "175btc",
             "link" : "http://www.175btc.com/"
         },
-        "axbt" : {
+        "/A-XBT/" : {
             "name" : "A-XBT",
             "link" : "http://www.a-xbt.com"
         },

--- a/pools.json
+++ b/pools.json
@@ -4,6 +4,10 @@
             "name" : "175btc",
             "link" : "http://www.175btc.com/"
         },
+        "axbt" : {
+            "name" : "A-XBT",
+            "link" : "http://www.a-xbt.com"
+        },
         "ASICMiner" : {
             "name" : "ASICMiner",
             "link" : "http://www.asicminer.co"
@@ -361,6 +365,10 @@
         "151T7r1MhizzJV6dskzzUkUdr7V8JxV2Dx" : {
             "name" : "myBTCcoin Pool",
             "link" : "http://www.mybtccoin.com/"
+        },
+        "1MFsp2txCPwMMBJjNNeKaduGGs8Wi1Ce7X" : {
+            "name" : "A-XBT",
+            "link" : "http://www.a-xbt.com/"
         },
         "1BUiW44WuJ2jiJgXiyxJVFMN8bc1GLdXRk" : {
             "name" : "TBDice",


### PR DESCRIPTION
Based on [this latest block](https://blockchain.info/tx/6cfab7be7159adcc98be20985d604352903dc3526ddc3cdcb5d935a4be39f985) the coinbase tag is "/A-XBT/" and not "axbt".