### PR TITLE
add new 21 Inc address

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -338,6 +338,10 @@
             "name" : "21 Inc.",
             "link" : "https://21.co/"
         },
+        "1GC6HxDvnchDdb5cGkFXsJMZBFRsKAXfwi" : {
+            "name" : "21 Inc.",
+            "link" : "https://21.co/"
+        },
         "1MimPd6LrPKGftPRHWdfk8S3KYBfN4ELnD" : {
             "name" : "digitalBTC",
             "link" : "http://digitalbtc.com/"


### PR DESCRIPTION
Looks like 21 Inc is now using a new generation address, coins from the previous known address(1CdJi2xRTXJF6CEJqNHYyQDNEcM3X7fUhD) were swept through this address. 