### PR TITLE
add 1Hash pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -243,6 +243,10 @@
         "/BCMonster/" : {
             "name": "BCMonster",
             "link": "http://www.bcmonster.com/"
+        },
+        "Mined by 1hash.com" : {
+            "name": "1Hash",
+            "link": "http://www.1hash.com/"
         }
     },
     "payout_addresses" : {
@@ -437,6 +441,10 @@
         "1MPxhNkSzeTNTHSZAibMaS8HS1esmUL1ne" : {
             "name" : "Eobot",
             "link" : "https://eobot.com/"
+        },
+        "1F1xcRt8H8Wa623KqmkEontwAAVqDSAWCV" : {
+            "name" : "1Hash",
+            "link" : "http://www.1hash.com/"
         }
     }
 }


### PR DESCRIPTION
[This](https://blockchain.info/tx/59e7532c046ed825683306d6498d886209de02d412dd3f1dc55c55f87ea1c516) block was mined by 1hash.com. Note that the tag is an OP_RETURN of the generation transaction. The OP_RETURN decoded contains the string "Mined by 1hash.com". Blocktrail appears to decode the OP_RETURN properly [here](https://www.blocktrail.com/BTC/tx/59e7532c046ed825683306d6498d886209de02d412dd3f1dc55c55f87ea1c516#tx_messages) while blockchain.info only says "Unable to decode output address".

Transaction:
```json
{
  "txid": "59e7532c046ed825683306d6498d886209de02d412dd3f1dc55c55f87ea1c516",
  "size": 135,
  "version": 1,
  "locktime": 0,
  "vin": [
    {
      "coinbase": "03c61e06",
      "sequence": 4294967295
    }
  ],
  "vout": [
    {
      "value": 25.76452213,
      "n": 0,
      "scriptPubKey": {
        "asm": "OP_DUP OP_HASH160 99c02ebccad91945bcb469e5a66240b3c7ee614e OP_EQUALVERIFY OP_CHECKSIG",
        "hex": "76a91499c02ebccad91945bcb469e5a66240b3c7ee614e88ac",
        "reqSigs": 1,
        "type": "pubkeyhash",
        "addresses": [
          "1F1xcRt8H8Wa623KqmkEontwAAVqDSAWCV"
        ]
      }
    }, 
    {
      "value": 0.00000000,
      "n": 1,
      "scriptPubKey": {
        "asm": "OP_RETURN [error]",
        "hex": "6a28124d696e65642062792031686173682e636f6d9fcd0576f3b70a2cf3b70a2ca6290090",
        "type": "nonstandard"
      }
    }
  ]
}
```