### PR TITLE
add UNOMP pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -445,6 +445,10 @@
         "1F1xcRt8H8Wa623KqmkEontwAAVqDSAWCV" : {
             "name" : "1Hash",
             "link" : "http://www.1hash.com/"
+        },
+        "1BRY8AD7vSNUEE75NjzfgiG18mWjGQSRuJ" : {
+            "name" : "UNOMP",
+            "link" : "http://199.115.116.7:8925/"
         }
     }
 }


### PR DESCRIPTION
Not sure which organization runs this pool but the block finds are [here](http://199.115.116.7:8925/api/getblocksstats). Verified via stratum decode as well. Block finds on blockchain.info are [here](https://blockchain.info/address/1BRY8AD7vSNUEE75NjzfgiG18mWjGQSRuJ).