### PR TITLE
add secondary address for Patel's Mining pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -449,6 +449,10 @@
         "19RE4mz2UbDxDVougc6GGdoT4x5yXxwFq2" : {
             "name" : "Patel's Mining pool",
             "link" : "http://patelsminingpool.com/"
+        },
+        "197miJmttpCt2ubVs6DDtGBYFDroxHmvVB" : {
+            "name" : "Patel's Mining pool",
+            "link" : "http://patelsminingpool.com/"
         }
     }
 }


### PR DESCRIPTION
This pool seems to be using two generation addresses, last block was mined to this address https://blockchain.info/tx/e67fc7ddd1ab8dce095be3a1965cefbfd59c3cc38d76ddac58fbb4b556ef5dc9