### PR TITLE
Fix ViaBTC tag

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -248,6 +248,10 @@
             "name": "HaoBTC",
             "link": "https://haobtc.com/"
         },
+        "viabtc.com deploy" : {
+            "name": "ViaBTC",
+            "link": "http://viabtc.com/"
+        },
         "/ViaBTC/" : {
             "name": "ViaBTC",
             "link": "http://viabtc.com/"

--- a/pools.json
+++ b/pools.json
@@ -248,7 +248,7 @@
             "name": "HaoBTC",
             "link": "https://haobtc.com/"
         },
-        "viabtc.com deploy" : {
+        "/ViaBTC/" : {
             "name": "ViaBTC",
             "link": "http://viabtc.com/"
         }


### PR DESCRIPTION
Here is a couple of examples of the coinbase data in ViaBTC blocks:
- h4/ViaBTC/Via Bitcoin Making The World a Better Place/H!
- Nh&/ViaBTC/viabtc.com is accessible now./8ve: