### PR TITLE
Added gbminers pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -4,6 +4,10 @@
             "name" : "175btc",
             "link" : "http://www.175btc.com/"
         },
+        "/mined by gbminers/" : {
+            "name" : "GBMiners",
+            "link" : "http://gbminers.com/"
+        },
         "/A-XBT/" : {
             "name" : "A-XBT",
             "link" : "http://www.a-xbt.com"


### PR DESCRIPTION
Added btcsig for new pool: gbminers.com

Link on blockchain.info: https://blockchain.info/blocks/52.66.51.105

Block found by the pool: https://blockchain.info/block-height/427549

Current Hash Rate of the pool: 9 PH/s