### PR TITLE
rebrand pool.btc.com

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -475,7 +475,7 @@
             "link" : "http://viabtc.com/"
         },
         "3NA8hsjfdgVkmmVS9moHmkZsVCoLxUkvvv" : {
-            "name" : "BTCPool",
+            "name" : "BTC.com",
             "link" : "https://pool.btc.com"
         }
     }


### PR DESCRIPTION
Hi, we just rebrand from `BTCPool` to `BTC.com`.