### PR TITLE
add phash.io pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -267,6 +267,14 @@
         "/Bitcoin-India/" : {
             "name": "Bitcoin India",
             "link": "https://bitcoin-india.org/"
+        },
+        "/phash.io/" : {
+            "name": "PHash.IO",
+            "link": "http://phash.io/"
+        },
+        "/phash.cn/" : {
+            "name": "PHash.IO",
+            "link": "http://phash.io/"
         }
     },
     "payout_addresses" : {


### PR DESCRIPTION
Block found by phash.io:
https://blockchain.info/tx/78d236bb3c099108c066bd1382f1215372336f21c1fef736b4c4a5c79ed43664
[Previous](https://blockchain.info/tx/cb3673b21a453b850d2cf4f9f6b45a3eaa4a6d7acef7cc3aaad8e40e2a4c397f) blocks that used phash.cn coinbase tag were [swept](https://blockchain.info/tx/4beffbbfe921acda8d70823f218211ba7dacc844ebe94ea389fd6fa8c49c23a3) into the phash.io generation address.