### PR TITLE
add GoGreenLight pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -485,6 +485,10 @@
         "3NA8hsjfdgVkmmVS9moHmkZsVCoLxUkvvv" : {
             "name" : "BTC.com",
             "link" : "https://pool.btc.com"
+        },
+        "18EPLvrs2UE11kWBB3ABS7Crwj5tTBYPoa" : {
+            "name" : "GoGreenLight",
+            "link" : "http://www.gogreenlight.se/"
         }
     }
 }


### PR DESCRIPTION
This is not confirmed personally but there are [reports](https://www.reddit.com/r/btc/comments/52qaxb/nobody_noticed_but_as_there_are_new_bip109_miners/d7mspgp/) that this is the pool for [KNC's new owner](http://www.coindesk.com/knc-miner-acquisition-gogreenlight/).