### PR TITLE
add new Eobot address

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -462,6 +462,10 @@
             "name" : "Eobot",
             "link" : "https://eobot.com/"
         },
+        "16GsNC3q6KgVXkUX7j7aPxSUdHrt1sN2yN" : {
+            "name" : "Eobot",
+            "link" : "https://eobot.com/"
+        },
         "1F1xcRt8H8Wa623KqmkEontwAAVqDSAWCV" : {
             "name" : "1Hash",
             "link" : "http://www.1hash.com/"


### PR DESCRIPTION
Confirmed new sha.eobot.com:3333 generation address matches 16GsNC3q6KgVXkUX7j7aPxSUdHrt1sN2yN via stratum decode.