### PR TITLE
add BTC.TOP pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -279,6 +279,10 @@
         "/phash.cn/" : {
             "name": "PHash.IO",
             "link": "http://phash.io/"
+        },
+        "/BTC.TOP/" : {
+            "name": "BTC.TOP",
+            "link": "http://btc.top/"
         }
     },
     "payout_addresses" : {
@@ -517,6 +521,10 @@
         "1AZ6BkCo4zgTuuLpRStJH8iNsehXTMp456" : {
             "name" : "Bitcoin India",
             "link" : "https://bitcoin-india.org/"
+        },
+        "1Hz96kJKF2HLPGY15JWLB5m9qGNxvt8tHJ" : {
+            "name" : "BTC.TOP",
+            "link" : "http://btc.top/"
         }
     }
 }


### PR DESCRIPTION
Seeing blocks being found with btc.cop in coinbase sig.

https://blockchain.info/tx/d662de853b1b39ac486021b41ac53e3fedf0bdddae1e4f3278c37e8928300be6