### PR TITLE
add btc.com coinbase sig detection

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -287,6 +287,10 @@
         "/ConnectBTC - Home for Miners/" : {
             "name": "ConnectBTC",
             "link": "https://www.connectbtc.com/"
+        },
+        "/BTC.COM/" : {
+            "name": "BTC.com",
+            "link": "https://pool.btc.com"
         }
     },
     "payout_addresses" : {


### PR DESCRIPTION
should some blocks like [this one](https://blockchain.info/tx/3753472365a4030549502c0030d84c249c11bdd34683144236796e026aa61604) getting missed