### PR TITLE
add rigpool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -303,6 +303,10 @@
         "/CANOE/" : {
             "name": "CANOE",
             "link": "https://www.canoepool.com"
+        },
+        "/RigPool.com/" : {
+            "name": "RigPool",
+            "link": "https://www.rigpool.com"
         }
     },
     "payout_addresses" : {
@@ -565,6 +569,10 @@
         "1Afcpc2FpPnREU6i52K3cicmHdvYRAH9Wo" : {
             "name" : "CANOE",
             "link" : "https://www.canoepool.com"
+        },
+        "1JpKmtspBJQVXK67DJP64eBJcAPhDvJ9Er" : {
+            "name" : "RigPool",
+            "link" : "https://www.rigpool.com"
         }
     }
 }


### PR DESCRIPTION
This pool has found one [block](https://blockchain.info/tx/524fae17bb776cd86760202f029f003c3c51fea4197d2cac116fa37164907af9) Coinbase sig was changed afterward, which verified via stratum decoder to be "/RigPool.com/". The sig listed on the website("/RigPool/") is incorrect.