### PR TITLE
add BCMonster generation address tagging

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -581,6 +581,10 @@
         "1KsFhYKLs8qb1GHqrPxHoywNQpet2CtP9t" : {
             "name" : "Bixin",
             "link" : "https://bixin.com/common/pool_landing"
+        },
+        "1E18BNyobcoiejcDYAz5SjbrzifNDEpM88" : {
+            "name" : "BCMonster",
+            "link" : "http://www.bcmonster.com"
         }
     }
 }


### PR DESCRIPTION
The [latest block](https://blockchain.info/tx/982eedb47db0ec3b0c2045ac036951c7592ea6bc6ac0a0e2bcba08cdcffc7986) by this pool didn't have the coinbase tag for some reason.