### PR TITLE
Add new Telco 214 addresses

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -466,6 +466,18 @@
             "name" : "Telco 214",
             "link" : "http://www.telco214.com"
         },
+        "1CNq2FAw6S5JfBiDkjkYJUVNQwjoeY4Zfi" : {
+            "name" : "Telco 214",
+            "link" : "http://www.telco214.com"
+        },
+        "1LXWA3EEEwPixQcyFWXKX2hWHpkDoLknZW" : {
+            "name" : "Telco 214",
+            "link" : "http://www.telco214.com"
+        },
+        "14M1pQ5KKeqmDrmqKyZEnaxAGJfBPrfWvQ" : {
+            "name" : "Telco 214",
+            "link" : "http://www.telco214.com"
+        },
         "152f1muMCNa7goXYhYAQC61hxEgGacmncB" : {
             "name" : "BTCC Pool",
             "link" : "https://pool.btcc.com"


### PR DESCRIPTION
New addresses for Telco 214 seen in [this](https://blockchain.info/block/000000000000000001957c751e835813c62b923940d6a77354807f62ccc25083) and [this](https://blockchain.info/block/000000000000000000e839e4a479f8b96384a80623776d7a74fe36d1a10ac79b) block, identified via common sweep address with other known Telco 214 blocks.