### PR TITLE
Add MiningKings pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -323,6 +323,10 @@
         "/$Mined by 7pool.com/" : {
             "name": "7pool",
             "link": "https://7pool.com/"
+        },
+        "/mined by poopbut/" : {
+            "name": "MiningKings",
+            "link": "https://miningkings.com/"
         }
     },
     "payout_addresses" : {
@@ -633,6 +637,18 @@
         "1JLc3JxvpdL1g5zoX8sKLP4BkJQiwnJftU" : {
             "name" : "7pool",
             "link" : "https://7pool.com/"
+        },
+        "1EowSPumj9D9AMTpE64Jr7vT3PJDNopVcz" : {
+            "name" : "MiningKings",
+            "link" : "https://miningkings.com/"
+        },
+        "1ApE99VM5RJzMRRtwd2JMgmkGabtJqoMEz" : {
+            "name" : "MiningKings",
+            "link" : "https://miningkings.com/"
+        },
+        "1KGbsDDAgJN2HDNBjmMHp9828qATo5B9c9" : {
+            "name" : "MiningKings",
+            "link" : "https://miningkings.com/"
         }
     }
 }


### PR DESCRIPTION
[This](https://miningkings.com/index.php?k=pblocks) is the blockpage for this pool, confirmed via stratum decode as well. And yes the [blocks](https://blockchain.info/tx/2b13a24cf84f8364ad551f8e7ce610ef72371ce2911482a259d3fb4d6ff44a8d) really do use the coinbase sig `/mined by poopbut/`.