### PR TITLE
Rename DCEX as DCExploration

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -333,8 +333,8 @@
             "link": "https://miningkings.com/"
         },
         "/DCEX/" : {
-            "name" : "DCEX",
-            "link" : "http://dcexploration.cn"
+            "name" : "DCExploration",
+            "link" : ""
         },
         "/58coin.com/" : {
             "name" : "58COIN",


### PR DESCRIPTION
Hello, we decide to rename our pool as DCExploration, and no valid portal links for now. Please help to merge it. Thank you very much!