### PR TITLE
Add OwnBlock mining pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -487,6 +487,10 @@
         "/PureBTC.COM/": {
             "name": "PureBTC.COM",
             "link": "https://purebtc.com"
+        },
+        "/ownblock/": {
+            "name": "OwnBlock",
+            "link": "https://ownblock.io"
         }
     },
     "payout_addresses": {


### PR DESCRIPTION
Adds OwnBlock (https://ownblock.io), a cryptocurrency mining pool supporting Bitcoin Cash, Bitcoin and Monero.

Coinbase tag: `/ownblock/`

Block: 952870